### PR TITLE
Obtain own version without external functions

### DIFF
--- a/labscript/__init__.py
+++ b/labscript/__init__.py
@@ -39,8 +39,4 @@ check_version('labscript_utils', '2.2', '3')
 #    elif sys.argv[0]:
 #        labscript_init(sys.argv[0].replace('.py','.h5'), labscript_file=sys.argv[0], new=True, overwrite=overwrite)
 
-from labscript_utils.versions import get_version, NoVersionInfo
-from pathlib import Path
-__version__ = get_version(__name__, import_path=Path(__file__).parent.parent)
-if __version__ is NoVersionInfo:
-    __version__ = None
+from .__version__ import __version__

--- a/labscript/__version__.py
+++ b/labscript/__version__.py
@@ -1,0 +1,21 @@
+import os
+from pathlib import Path
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
+VERSION_SCHEME = {
+    "version_scheme": os.getenv("SCM_VERSION_SCHEME", "guess-next-dev"),
+    "local_scheme": os.getenv("SCM_LOCAL_SCHEME", "node-and-date"),
+}
+
+root = Path(__file__).parent.parent
+if (root / '.git').is_dir():
+    from setuptools_scm import get_version
+    __version__ = get_version(root, **VERSION_SCHEME)
+else:
+    try:
+        __version__ = importlib_metadata.version(__package__)
+    except importlib_metadata.PackageNotFoundError:
+        __version__ = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.6
 install_requires =
+  importlib_metadata ; python_version<'3.8'
   labscript_utils>=2.14.0
   numpy>=1.15
   scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.6
 install_requires =
-  importlib_metadata ; python_version<'3.8'
+  importlib_metadata
   labscript_utils>=2.14.0
   numpy>=1.15
   scipy


### PR DESCRIPTION
Per labscript-suite/runmanager#81, with the addition of making the importlib_metadata requirement python<'3.8'.