### PR TITLE
Save git info

### DIFF
--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -2206,6 +2206,14 @@ def save_labscripts(hdf5_file):
                             info, err = process.communicate()
                             if info or err:
                                 hdf5_file[save_path].attrs['hg ' + str(command[0])] = info.decode('utf-8') + '\n' + err.decode('utf-8')
+                    if compiler.save_git_info:
+                        module_filename = os.path.split(path)[1]
+                        git_commands = [['branch', '--show-current'], ['rev-parse', '--verify', 'HEAD'], ['diff', 'HEAD', module_filename]]
+                        for command in git_commands:
+                            process = subprocess.Popen(['git'] + command, cwd=os.path.split(path)[0], stdout=subprocess.PIPE,
+                                                       stderr=subprocess.PIPE, startupinfo=startupinfo)
+                            info, err = process.communicate()
+                            hdf5_file[save_path].attrs['git ' + str(command[0])] = info.decode('utf-8') + '\n' + err.decode('utf-8')
     except ImportError:
         pass
     except WindowsError if os.name == 'nt' else None:
@@ -2540,6 +2548,7 @@ def labscript_cleanup():
     compiler.time_markers = {}
     compiler._PrimaryBLACS = None
     compiler.save_hg_info = True
+    compiler.save_git_info = True
     compiler.shot_properties = {}
 
 class compiler(object):
@@ -2560,6 +2569,7 @@ class compiler(object):
     time_markers = {}
     _PrimaryBLACS = None
     save_hg_info = True
+    save_git_info = True
     shot_properties = {}
 
     # safety measure in case cleanup is called before init

--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -2212,7 +2212,7 @@ def save_labscripts(hdf5_file):
                                 hdf5_file[save_path].attrs['hg ' + str(command[0])] = info.decode('utf-8') + '\n' + err.decode('utf-8')
                     if compiler.save_git_info:
                         module_filename = os.path.split(path)[1]
-                        git_commands = [['branch', '--show-current'], ['rev-parse', 'HEAD'], ['diff', 'HEAD', module_filename]]
+                        git_commands = [['branch', '--show-current'], ['describe', '--always', 'HEAD'], ['rev-parse', 'HEAD'], ['diff', 'HEAD', module_filename]]
                         process_list = []
                         for command in git_commands:
                             process = subprocess.Popen(['git'] + command, cwd=os.path.split(path)[0], stdout=subprocess.PIPE,

--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -2201,18 +2201,24 @@ def save_labscripts(hdf5_file):
                     hdf5_file.create_dataset(save_path, data=open(path).read())
                     if compiler.save_hg_info:
                         hg_commands = [['log', '--limit', '1'], ['status'], ['diff']]
+                        process_list = []
                         for command in hg_commands:
                             process = subprocess.Popen(['hg'] + command + [os.path.split(path)[1]], cwd=os.path.split(path)[0],
                                                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=startupinfo)
+                            process_list.append(process)
+                        for process, command in zip(process_list, hg_commands):
                             info, err = process.communicate()
                             if info or err:
                                 hdf5_file[save_path].attrs['hg ' + str(command[0])] = info.decode('utf-8') + '\n' + err.decode('utf-8')
                     if compiler.save_git_info:
                         module_filename = os.path.split(path)[1]
                         git_commands = [['branch', '--show-current'], ['rev-parse', '--verify', 'HEAD'], ['diff', 'HEAD', module_filename]]
+                        process_list = []
                         for command in git_commands:
                             process = subprocess.Popen(['git'] + command, cwd=os.path.split(path)[0], stdout=subprocess.PIPE,
                                                        stderr=subprocess.PIPE, startupinfo=startupinfo)
+                            process_list.append(process)
+                        for process, command in zip(process_list, git_commands):
                             info, err = process.communicate()
                             hdf5_file[save_path].attrs['git ' + str(command[0])] = info.decode('utf-8') + '\n' + err.decode('utf-8')
     except ImportError:

--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -2212,7 +2212,7 @@ def save_labscripts(hdf5_file):
                                 hdf5_file[save_path].attrs['hg ' + str(command[0])] = info.decode('utf-8') + '\n' + err.decode('utf-8')
                     if compiler.save_git_info:
                         module_filename = os.path.split(path)[1]
-                        git_commands = [['branch', '--show-current'], ['rev-parse', '--verify', 'HEAD'], ['diff', 'HEAD', module_filename]]
+                        git_commands = [['branch', '--show-current'], ['rev-parse', 'HEAD'], ['diff', 'HEAD', module_filename]]
                         process_list = []
                         for command in git_commands:
                             process = subprocess.Popen(['git'] + command, cwd=os.path.split(path)[0], stdout=subprocess.PIPE,

--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -31,6 +31,7 @@ from functools import wraps
 
 import labscript_utils.h5_lock, h5py
 import labscript_utils.properties
+from labscript_utils.labconfig import LabConfig
 
 # This imports the default Qt library that other labscript suite code will
 # import as well, since it all uses qtutils. By having a Qt library already
@@ -2547,8 +2548,8 @@ def labscript_cleanup():
     compiler.wait_delay = 0
     compiler.time_markers = {}
     compiler._PrimaryBLACS = None
-    compiler.save_hg_info = True
-    compiler.save_git_info = True
+    compiler.save_hg_info = LabConfig().getboolean('labscript', 'save_hg_info', fallback=True)
+    compiler.save_git_info = LabConfig().getboolean('labscript', 'save_git_info', fallback=False)
     compiler.shot_properties = {}
 
 class compiler(object):
@@ -2568,8 +2569,8 @@ class compiler(object):
     wait_delay = 0
     time_markers = {}
     _PrimaryBLACS = None
-    save_hg_info = True
-    save_git_info = True
+    save_hg_info = LabConfig().getboolean('labscript', 'save_hg_info', fallback=True)
+    save_git_info = LabConfig().getboolean('labscript', 'save_git_info', fallback=False)
     shot_properties = {}
 
     # safety measure in case cleanup is called before init

--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -2224,7 +2224,7 @@ def save_labscripts(hdf5_file):
     except ImportError:
         pass
     except WindowsError if os.name == 'nt' else None:
-        sys.stderr.write('Warning: Cannot save Mercurial data for imported scripts. Check that the hg command can be run from the command line.\n')
+        sys.stderr.write('Warning: Cannot save version control data for imported scripts. Check that the hg and/or git command can be run from the command line.\n')
 
 
 def write_device_properties(hdf5_file):

--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -2212,7 +2212,7 @@ def save_labscripts(hdf5_file):
                                 hdf5_file[save_path].attrs['hg ' + str(command[0])] = info.decode('utf-8') + '\n' + err.decode('utf-8')
                     if compiler.save_git_info:
                         module_filename = os.path.split(path)[1]
-                        git_commands = [['branch', '--show-current'], ['describe', '--always', 'HEAD'], ['rev-parse', 'HEAD'], ['diff', 'HEAD', module_filename]]
+                        git_commands = [['branch', '--show-current'], ['describe', '--tags', '--always', 'HEAD'], ['rev-parse', 'HEAD'], ['diff', 'HEAD', module_filename]]
                         process_list = []
                         for command in git_commands:
                             process = subprocess.Popen(['git'] + command, cwd=os.path.split(path)[0], stdout=subprocess.PIPE,

--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -2287,10 +2287,12 @@ def save_labscripts(hdf5_file):
                         continue
                     hdf5_file.create_dataset(save_path, data=open(path).read())
                     with _vcs_cache_rlock:
-                        if path not in _vcs_cache:
-                            # Add file to watch list and create its entry in the cache.
-                            _file_watcher.add_file(path)
-                            _file_watcher_callback(path, None, None)
+                        already_cached = path in _vcs_cache
+                    if not already_cached:
+                        # Add file to watch list and create its entry in the cache.
+                        _file_watcher.add_file(path)
+                        _file_watcher_callback(path, None, None)
+                    with _vcs_cache_rlock:
                         # Save the cached vcs output to the file.
                         for command, info, err in _vcs_cache[path]:
                             attribute_str = command[0] + ' ' + command[1]


### PR DESCRIPTION
Proposed changes:

* Support saving git repo information to a shot file, similar to how hg info is saved. The output from following commands are saved:
  * `git branch --show-current` gives the name of the current branch.
  * `git describe --tags --always HEAD` gives the name of the most recent tag reachable from the current commit.
    * If the current commit isn't tagged, a suffix showing the number of commits since the most recent tag and a shortened hash for the current commit are shown.
    * The `--tags` flag makes it look for lightweight tags as well instead of just annotated tags.
    * The `--always` flag makes it so that If no tag is reachable from the current commit, just the shortened hash is returned.
  * `git rev-parse HEAD` returns the full hash of the current commit.
  * `git diff HEAD module_filename` returns a diff between the file on disk and the version in the current commit.
* Allow turning on/off saving of git/hg info with setting in labconfig.
  * These are controlled by the `save_hg_info` and `save_git_info` options in the `[labscript]` section of the labconfig.
  * To avoid changing the existing behavior, `save_hg_info` defaults to `True` and `save_git_info` defaults to `False`.
* Run the calls to git/hg for a given file in parallel. This is straightforward since they run in separate processes anyway.
  * On my machine, these are the timings to run the git/hg commands on five files during compilation:
    * hg: 1.788 seconds without parallelization and 0.695 seconds with parallelization, a 2.57x speedup.
    * git: 0.707 seconds without parallelization and 0.283 seconds with parallelization, a 2.50x speedup.
* Cache results from calls to git/hg to speed up compilation as suggested in #38 
  * A `FileWatcher` is used to track when files are modified, then the callback updates the cache immediately.
  * Files are added to the `FileWatcher` during the first call to `save_labscripts()` that uses it, so the first shot compilation is a bit slower than others. The cache is updated asynchronously so future calls to `save_labscripts` are fast even if the file is modified. After the first run, they typically take 20 ms to 40 ms for 6 files on my machine.


Resolves #38.