### PR TITLE
Fix #78: labscript.py accidentally overwrites dedent()

### DIFF
--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -39,10 +39,10 @@ import labscript_utils.properties
 # other code is using:
 import qtutils
 
+from pylab import *
+
 from labscript_utils import dedent
 from labscript_utils.properties import set_attributes
-
-from pylab import *
 
 import labscript.functions as functions
 try:


### PR DESCRIPTION
As explained in #78, the `from pylab import *` line in `labscript.py` imports `dedent()` from `matplotlib.cbook` which overwrites the desired `dedent()` imported from `labscript_utils`. This PR switches the order of those import statements so that `dedent()` points to `labscript_utils.dedent()`.