### PR TITLE
Mock `labscript_utils` to prevent RTD from trying to launch zprocess.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,10 @@ from pathlib import Path
 from m2r import MdInclude
 from recommonmark.transform import AutoStructify
 from jinja2 import FileSystemLoader, Environment
+try:
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
 # -- Project information (unique to each project) -------------------------------------
 
@@ -22,7 +26,7 @@ project = "labscript"
 copyright = "2020, labscript suite"
 author = "labscript suite contributors"
 
-from labscript import __version__ as version  # noqa: E402
+version = importlib_metadata.version('labscript')
 
 release = version
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,6 +51,7 @@ extensions = [
 autodoc_typehints = 'description'
 autosummary_generate = True
 add_module_names = False
+autodoc_mock_imports = ['labscript_utils']
 
 # Prefix each autosectionlabel with the name of the document it is in and a colon
 autosectionlabel_prefix_document = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,6 +55,7 @@ extensions = [
 autodoc_typehints = 'description'
 autosummary_generate = True
 add_module_names = False
+autodoc_mock_imports = ['labscript_utils']
 
 # Prefix each autosectionlabel with the name of the document it is in and a colon
 autosectionlabel_prefix_document = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,6 @@ extensions = [
 autodoc_typehints = 'description'
 autosummary_generate = True
 add_module_names = False
-autodoc_mock_imports = ['labscript_utils']
 
 # Prefix each autosectionlabel with the name of the document it is in and a colon
 autosectionlabel_prefix_document = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
   numpy>=1.15
   scipy
   matplotlib
+  zprocess==2.20.3
 
 [options.extras_require]
 docs = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
   numpy>=1.15
   scipy
   matplotlib
-  zprocess==2.20.3
+  zprocess==2.20.2
 
 [options.extras_require]
 docs = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
   importlib_metadata
-  labscript_utils==3.1.0
+  labscript_utils>=3.0.0
   numpy>=1.15
   scipy
   matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,10 @@ packages = find:
 python_requires = >=3.6
 install_requires =
   importlib_metadata
-  labscript_utils>=3.0.0
+  labscript_utils==3.1.0
   numpy>=1.15
   scipy
   matplotlib
-  zprocess==2.20.1
 
 [options.extras_require]
 docs = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
   numpy>=1.15
   scipy
   matplotlib
-  zprocess==2.20.2
+  zprocess==2.20.1
 
 [options.extras_require]
 docs = 


### PR DESCRIPTION
This attempts to fix the new failings of the read the docs build, described in labscript-suite/labscript-suite#65.