### PR TITLE
Allow passthrough of other kwargs in DDS gate DigitalOut specification.

### DIFF
--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -2799,7 +2799,7 @@ class DDSQuantity(Device):
             digital_gate (dict, optional): Configures a digital output to use as an enable/disable
                 gate for the output. Should contain keys `'device'` and `'connection'`
                 with arguments for the `parent_device` and `connection` for instantiating
-                the :obj:`DigitalOut`.
+                the :obj:`DigitalOut`. All other (optional) keys are passed as kwargs.
             freq_limits (tuple, optional): `(lower, upper)` limits for the 
                 frequency of the output
             freq_conv_class (:obj:`labscript_utils:labscript_utils.unitconversions`, optional): 
@@ -2851,8 +2851,10 @@ class DDSQuantity(Device):
         self.phase = AnalogQuantity(self.name + '_phase', self, 'phase', phase_limits, phase_conv_class, phase_conv_params)
 
         self.gate = None
-        if 'device' in digital_gate and 'connection' in digital_gate:            
-            self.gate = DigitalOut(name + '_gate', digital_gate['device'], digital_gate['connection'])
+        if 'device' in digital_gate and 'connection' in digital_gate:
+            dev = digital_gate.pop('device')
+            conn = digital_gate.pop('connection')
+            self.gate = DigitalOut(name + '_gate', dev, conn, **digital_gate)
         # Did they only put one key in the dictionary, or use the wrong keywords?
         elif len(digital_gate) > 0:
             raise LabscriptError('You must specify the "device" and "connection" for the digital gate of %s.' % (self.name))
@@ -2980,7 +2982,7 @@ class StaticDDS(Device):
             digital_gate (dict, optional): Configures a digital output to use as an enable/disable
                 gate for the output. Should contain keys `'device'` and `'connection'`
                 with arguments for the `parent_device` and `connection` for instantiating
-                the :obj:`DigitalOut`.
+                the :obj:`DigitalOut`. All other (optional) keys are passed as kwargs.
             freq_limits (tuple, optional): `(lower, upper)` limits for the 
                 frequency of the output
             freq_conv_class (:obj:`labscript_utils:labscript_utils.unitconversions`, optional): 
@@ -3030,8 +3032,10 @@ class StaticDDS(Device):
         self.amplitude = StaticAnalogQuantity(self.name+'_amp',self,'amp',amp_limits,amp_conv_class,amp_conv_params)
         self.phase = StaticAnalogQuantity(self.name+'_phase',self,'phase',phase_limits,phase_conv_class,phase_conv_params)        
         
-        if 'device' in digital_gate and 'connection' in digital_gate:            
-            self.gate = DigitalOut(self.name+'_gate',digital_gate['device'],digital_gate['connection'])
+        if 'device' in digital_gate and 'connection' in digital_gate:
+            dev = digital_gate.pop('device')
+            conn = digital_gate.pop('connection')
+            self.gate = DigitalOut(name + '_gate', dev, conn, **digital_gate)
         # Did they only put one key in the dictionary, or use the wrong keywords?
         elif len(digital_gate) > 0:
             raise LabscriptError('You must specify the "device" and "connection" for the digital gate of %s.'%(self.name))


### PR DESCRIPTION
In particular, this allows for the digital gate of a DDS Quantity to have inverted logic.