### PR TITLE
Change default of save_hg_info to

### DIFF
--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -74,7 +74,7 @@ else:
     startupinfo = None
 
 # Extract settings from labconfig
-_SAVE_HG_INFO = LabConfig().getboolean('labscript', 'save_hg_info', fallback=True)
+_SAVE_HG_INFO = LabConfig().getboolean('labscript', 'save_hg_info', fallback=False)
 _SAVE_GIT_INFO = LabConfig().getboolean('labscript', 'save_git_info', fallback=False)
         
 class config(object):


### PR DESCRIPTION
There is no reason that we should be default trying to save hg info (particularly since we have moved to github).  In my case, this cased a problem in runmanager whereby the compile thread would hard-crash when the vcs function could not find the hg executable.  Of course one solution here is to use the save_hg_info (or save_git_info) option in the labconfig file, but since these do not appear in the default files I think it is better to turn off the option be default.