### PR TITLE
modify enable/disable definition for Trigger

### DIFF
--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -2694,11 +2694,13 @@ class Trigger(DigitalOut):
         """
         DigitalOut.__init__(self,name,parent_device,connection, **kwargs)
         self.trigger_edge_type = trigger_edge_type
-        if self.trigger_edge_type == 'rising':
+        if ((self.trigger_edge_type == 'rising' and not self.inverted) or 
+            (self.trigger_edge_type == 'falling' and self.inverted)):
             self.enable = self.go_high
             self.disable = self.go_low
             self.allowed_states = {1:'enabled', 0:'disabled'}
-        elif self.trigger_edge_type == 'falling':
+        elif ((self.trigger_edge_type == 'rising' and self.inverted) or 
+            (self.trigger_edge_type == 'falling' and not self.inverted)):
             self.enable = self.go_low
             self.disable = self.go_high
             self.allowed_states = {1:'disabled', 0:'enabled'}


### PR DESCRIPTION
I added additional logic to modify how enable() and disable() are defined for a Trigger.

To illustrate, here is a use case:
- my TriggerableDevice is triggered on a rising edge
- the digital output being used to trigger the device has a breakout board which, for whatever reason, inverts its output.

So I would then instantiate my Trigger as `Trigger(..., inverted=True, trigger_edge_type='rising')` so that it matches with my TriggerableDevice.

This seems to make sense, if this was the intended use case of the `inverted` argument. This is less misleading than using  `trigger_edge_type='falling'` for both Trigger and TriggerableDevice, which is a (working) workaround. However, merging this would break the workaround.