### PR TITLE
Remove latent dependency on runmanager due to `get_shot_globals`.

### DIFF
--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -706,8 +706,8 @@ def stop(t, target_cycle_time=None, cycle_time_delay_after_programming=False):
 # TO_DELETE:runmanager-batchompiler-agnostic
 #   entire function load_globals can be deleted
 def load_globals(hdf5_filename):
-    import runmanager
-    params = runmanager.get_shot_globals(hdf5_filename)
+    import labscript_utils.shot_utils
+    params = labscript_utils.shot_utils.get_shot_globals(hdf5_filename)
     with h5py.File(hdf5_filename,'r') as hdf5_file:
         for name in params.keys():
             if name in globals() or name in locals() or name in _builtins_dict:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
   importlib_metadata
-  labscript_utils>=3.0.0
+  labscript_utils>=3.3.0
   numpy>=1.15
   scipy
   matplotlib


### PR DESCRIPTION
Bumps required version of `labscript_utils` to match.

Note that this dependency is in some level of deprecated code, and was not explicitly listed. Going to patch it out for now and worry about the batchcompiler-agnostic removal later.