### PR TITLE
Fixed error in a comment that gave the following warning.

### DIFF
--- a/labscript/utils.py
+++ b/labscript/utils.py
@@ -183,7 +183,7 @@ def max_or_zero(*args, **kwargs):
         **kwargs: Passed to `max()`.
 
     Returns:
-        : Max of \*args.
+        : Max of *args.
     """
     if not args:
         return 0


### PR DESCRIPTION
```
.../labscript/labscript/utils.py:176: SyntaxWarning: invalid escape sequence '\*'
  """Returns max of the arguments or zero if sequence is empty.
```