### PR TITLE
Don't have all devices have a BLACS_connection

### DIFF
--- a/labscript/base.py
+++ b/labscript/base.py
@@ -93,7 +93,6 @@ class Device(object):
         self.connection = connection
         self.start_order = start_order
         self.stop_order = stop_order
-        self.BLACS_connection = ""
         if start_order is not None and not isinstance(start_order, int):
             raise TypeError(
                 f"Error when instantiating {name}. start_order must be an integer, not "

--- a/labscript/labscript.py
+++ b/labscript/labscript.py
@@ -228,9 +228,6 @@ def generate_connection_table(hdf5_file):
     connection_table = []
     devicedict = {}
     
-    # Only use a string dtype as long as is needed:
-    max_BLACS_conn_length = 0
-
     for device in compiler.inventory:
         devicedict[device.name] = device
 
@@ -244,8 +241,6 @@ def generate_connection_table(hdf5_file):
         if hasattr(device,"BLACS_connection"):
             # Make sure it is a string!
             BLACS_connection = str(device.BLACS_connection)
-            if len(BLACS_connection) > max_BLACS_conn_length:
-                max_BLACS_conn_length = len(BLACS_connection)
         else:
             BLACS_connection = ""
             
@@ -269,11 +264,17 @@ def generate_connection_table(hdf5_file):
     
     connection_table.sort()
     vlenstring = h5py.special_dtype(vlen=str)
-    connection_table_dtypes = [('name','a256'), ('class','a256'), ('parent','a256'), ('parent port','a256'),
-                               ('unit conversion class','a256'), ('unit conversion params', vlenstring),
-                               ('BLACS_connection','a'+str(max_BLACS_conn_length)),
-                               ('properties', vlenstring)]
-    connection_table_array = empty(len(connection_table),dtype=connection_table_dtypes)
+    connection_table_dtypes = [
+        ('name', "a256"),
+        ('class', vlenstring),
+        ('parent', vlenstring),
+        ('parent port', vlenstring),
+        ('unit conversion class', vlenstring),
+        ('unit conversion params', vlenstring),
+        ('BLACS_connection', vlenstring),
+        ('properties', vlenstring),
+    ]
+    connection_table_array = empty(len(connection_table), dtype=connection_table_dtypes)
     for i, row in enumerate(connection_table):
         connection_table_array[i] = row
     dataset = hdf5_file.create_dataset('connection table', compression=compiler.compression, data=connection_table_array, maxshape=(None,))


### PR DESCRIPTION
This fixes a regression from #119 pointed out on the mailing list ([link](https://groups.google.com/g/labscriptsuite/c/KrUxJ9zxhOg/m/AUfITl2uAgAJ))

Setting this in the base class creates ordering requirements for when subclasses call the base class `__init__` in order for their `BLACS_connection` not to be overridden, and the bug in the mailing list is because NI DAQmx devices setting BLACS_connection do so before calling the base class `__init__`, so their BLACS connection attribute is getting overwritten.

If we wanted all devices to have a blacs_connection attribute, we could set it to None as a class attribute, then subclasses overriding it would be guaranteed to override it regardless of when they set it. But I think it's fine to just not have it on all classes.

This PR also simplifies the dtype logic that code was addressing, by using variable length strings for all fields where that is compatible with downstream code. Most code doesn't care, the data comes back as bytestrings regardless. However there's a bug in labscript_utils/properties.py where some code buggily tries to inspect the dtype and it fails if the name field is vlen. I'll fix that bug, but leaving the name field fixed length for compatibility with that buggy code.